### PR TITLE
Add nodeSelector to metal3's mariadb and baremetal-operator Deployment templates

### DIFF
--- a/charts/metal3-deploy/0.1.0/charts/baremetal-operator/templates/deployment.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/baremetal-operator/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: bmo-webhook-server-cert
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.dnsPolicy }}
       dnsPolicy:
         {{- toYaml . | nindent 8 }}

--- a/charts/metal3-deploy/0.1.0/charts/mariadb/templates/deployment.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/mariadb/templates/deployment.yaml
@@ -71,5 +71,9 @@ spec:
           timeoutSeconds: 10
         volumeMounts:
             {{- $volmounts }}
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- $volumes }}


### PR DESCRIPTION
At the moment in the metal3 chart Ironic communicates with MariaDB through localhost as configured here: https://github.com/suse-edge/charts/blob/079f28a17b5fe81481310821f3c6e5f1ec9d8f70/charts/metal3-deploy/0.1.0/charts/ironic/templates/configmap.yaml#L60

This works if Ironic and MariaDB Pods are running on the same node and with `hostNetwork: true` so in order to ensure the first condition this PR adds the `nodeSelector` field to the MariaDB Deployment template.

That field is added also to the Baremetal Operator Deployment template although in that case the communication with Ironic is done through the DNS name, so it's not mandatory for having it working but may be anyway useful https://github.com/suse-edge/charts/blob/079f28a17b5fe81481310821f3c6e5f1ec9d8f70/charts/metal3-deploy/0.1.0/charts/baremetal-operator/templates/configmap-ironic.yaml#L8