### PR TITLE
metal3: pvc use ReadWriteOnce when replicas=1

### DIFF
--- a/charts/metal3-deploy/0.1.0/charts/ironic/templates/pvc.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/ironic/templates/pvc.yaml
@@ -9,7 +9,13 @@ metadata:
   {{- end }}
 spec:
   accessModes:
+  {{- if .Values.persistence.ironic.accessMode }}
   - {{ .Values.persistence.ironic.accessMode }}
+  {{- else if eq (int .Values.replicaCount) 1 }}
+  - ReadWriteOnce
+  {{- else }}
+  - ReadWriteMany
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.ironic.size }}

--- a/charts/metal3-deploy/0.1.0/charts/ironic/values.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/ironic/values.yaml
@@ -451,6 +451,7 @@ persistence:
     # size of the ironic shared volume
     size: "1Gi"
     # accessMode of the ironic shared volume PVC
-    accessMode: "ReadWriteMany"
+    # If empty defaults to ReadWriteOnce when replicaCount=1 otherwise ReadWriteMany
+    accessMode: ""
     # flag to indicate to keep pvc upon helm uninstall
     keep: false

--- a/charts/metal3-deploy/0.1.0/charts/mariadb/templates/deployment.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/mariadb/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{.Values.replicaCount}}
   selector:
     matchLabels:
       {{- include "mariadb.selectorLabels" . | nindent 6 }}

--- a/charts/metal3-deploy/0.1.0/charts/mariadb/templates/pvc.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/mariadb/templates/pvc.yaml
@@ -8,7 +8,13 @@ metadata:
   {{- end }}
 spec:
   accessModes:
+  {{- if .Values.persistence.accessMode }}
   - {{ .Values.persistence.accessMode }}
+  {{- else if eq (int .Values.replicaCount) 1 }}
+  - ReadWriteOnce
+  {{- else }}
+  - ReadWriteMany
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/charts/metal3-deploy/0.1.0/charts/mariadb/values.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/mariadb/values.yaml
@@ -46,7 +46,8 @@ persistence:
   # size of the mariadb data volume
   size: "1Gi"
   # accessMode of the mariadb data volume PVC
-  accessMode: "ReadWriteMany"
+  # If empty defaults to ReadWriteOnce when replicaCount=1 otherwise ReadWriteMany
+  accessMode: ""
   # flag to indicate to keep pvc upon helm uninstall
   keep: false
 


### PR DESCRIPTION
Follow-up to #19 so we can test more easily with k3s single-node,
in which case the local-path provisioner does not support
ReadWriteMany, but since it's a single node/replica we can use
ReadWriteOnce instead if replicaCount=1