### PR TITLE
Add defaults for the Ironic service endpoints

### DIFF
--- a/charts/metal3-deploy/0.1.0/charts/baremetal-operator/templates/configmap-ironic.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/baremetal-operator/templates/configmap-ironic.yaml
@@ -1,7 +1,7 @@
-{{- $ironicApiHost := .Values.global.ironicApiHost }}
-{{- $ironicBootHost := .Values.global.ironicBootHost }}
-{{- $ironicInspectorHost := .Values.global.ironicInspectorHost }}
-{{- $ironicCacheHost := .Values.global.ironicCacheHost }}
+{{- $ironicApiHost := default (printf "api.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicApiHost }}
+{{- $ironicBootHost := default (printf "boot.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicBootHost }}
+{{- $ironicInspectorHost := default (printf "inspector.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicInspectorHost }}
+{{- $ironicCacheHost := default (printf "cache.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicCacheHost }}
 
 {{- if .Values.global.ironicIP }}
 {{- $ironicApiHost = print .Values.global.ironicIP ":6385" }}

--- a/charts/metal3-deploy/0.1.0/charts/ironic/templates/configmap.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/ironic/templates/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- include "ironic.labels" . | nindent 4 }}
 data:
   {{- $protocol := "http" }}
-  {{- $ironicApiHost := .Values.global.ironicApiHost }}
-  {{- $ironicBootHost := .Values.global.ironicBootHost }}
-  {{- $ironicInspectorHost := .Values.global.ironicInspectorHost }}
-  {{- $ironicCacheHost := .Values.global.ironicCacheHost }}
+  {{- $ironicApiHost := default (printf "api.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicApiHost }}
+  {{- $ironicBootHost := default (printf "boot.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicBootHost }}
+  {{- $ironicInspectorHost := default (printf "inspector.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicInspectorHost }}
+  {{- $ironicCacheHost := default (printf "cache.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicCacheHost }}
 
   {{- if .Values.global.ironicIP }}
   {{- $ironicApiHost = print .Values.global.ironicIP ":6385" }}

--- a/charts/metal3-deploy/0.1.0/charts/ironic/values.yaml
+++ b/charts/metal3-deploy/0.1.0/charts/ironic/values.yaml
@@ -110,22 +110,22 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: "{{ .Values.global.ironicApiHost }}"
+    - host: '{{ .Values.global.ironicApiHost | default (printf "api.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix 
           portname: api
-    - host: "{{ .Values.global.ironicInspectorHost }}"
+    - host: '{{ .Values.global.ironicInspectorHost | default (printf "inspector.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
           portname: inspector
-    - host: "{{ .Values.global.ironicBootHost }}"
+    - host: '{{ .Values.global.ironicBootHost | default (printf "boot.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
           portname: httpd
-    - host: "{{ .Values.global.ironicCacheHost }}"
+    - host: '{{ .Values.global.ironicCacheHost | default (printf "cache.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
@@ -136,10 +136,10 @@ ingress:
   tls:   
     - secretName: ironic-cacert 
       hosts:
-        - "{{ .Values.global.ironicApiHost }}"
-        - "{{ .Values.global.ironicBootHost }}"
-        - "{{ .Values.global.ironicCacheHost }}"
-        - "{{ .Values.global.ironicInspectorHost }}"
+        - '{{ .Values.global.ironicApiHost | default (printf "api.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicInspectorHost | default (printf "inspector.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicBootHost | default (printf "boot.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicCacheHost | default (printf "cache.ironic.%s" .Values.global.dnsDomain) }}'
   
 
 letsEncrypt:

--- a/packages/baremetal-operator/charts/templates/configmap-ironic.yaml
+++ b/packages/baremetal-operator/charts/templates/configmap-ironic.yaml
@@ -1,7 +1,7 @@
-{{- $ironicApiHost := .Values.global.ironicApiHost }}
-{{- $ironicBootHost := .Values.global.ironicBootHost }}
-{{- $ironicInspectorHost := .Values.global.ironicInspectorHost }}
-{{- $ironicCacheHost := .Values.global.ironicCacheHost }}
+{{- $ironicApiHost := default (printf "api.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicApiHost }}
+{{- $ironicBootHost := default (printf "boot.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicBootHost }}
+{{- $ironicInspectorHost := default (printf "inspector.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicInspectorHost }}
+{{- $ironicCacheHost := default (printf "cache.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicCacheHost }}
 
 {{- if .Values.global.ironicIP }}
 {{- $ironicApiHost = print .Values.global.ironicIP ":6385" }}

--- a/packages/ironic/charts/templates/configmap.yaml
+++ b/packages/ironic/charts/templates/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- include "ironic.labels" . | nindent 4 }}
 data:
   {{- $protocol := "http" }}
-  {{- $ironicApiHost := .Values.global.ironicApiHost }}
-  {{- $ironicBootHost := .Values.global.ironicBootHost }}
-  {{- $ironicInspectorHost := .Values.global.ironicInspectorHost }}
-  {{- $ironicCacheHost := .Values.global.ironicCacheHost }}
+  {{- $ironicApiHost := default (printf "api.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicApiHost }}
+  {{- $ironicBootHost := default (printf "boot.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicBootHost }}
+  {{- $ironicInspectorHost := default (printf "inspector.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicInspectorHost }}
+  {{- $ironicCacheHost := default (printf "cache.ironic.%s" .Values.global.dnsDomain) .Values.global.ironicCacheHost }}
 
   {{- if .Values.global.ironicIP }}
   {{- $ironicApiHost = print .Values.global.ironicIP ":6385" }}

--- a/packages/ironic/charts/values.yaml
+++ b/packages/ironic/charts/values.yaml
@@ -110,22 +110,22 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: "{{ .Values.global.ironicApiHost }}"
+    - host: '{{ .Values.global.ironicApiHost | default (printf "api.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix 
           portname: api
-    - host: "{{ .Values.global.ironicInspectorHost }}"
+    - host: '{{ .Values.global.ironicInspectorHost | default (printf "inspector.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
           portname: inspector
-    - host: "{{ .Values.global.ironicBootHost }}"
+    - host: '{{ .Values.global.ironicBootHost | default (printf "boot.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
           portname: httpd
-    - host: "{{ .Values.global.ironicCacheHost }}"
+    - host: '{{ .Values.global.ironicCacheHost | default (printf "cache.ironic.%s" .Values.global.dnsDomain) }}'
       paths:
         - path: /
           pathType: Prefix
@@ -136,10 +136,10 @@ ingress:
   tls:   
     - secretName: ironic-cacert 
       hosts:
-        - "{{ .Values.global.ironicApiHost }}"
-        - "{{ .Values.global.ironicBootHost }}"
-        - "{{ .Values.global.ironicCacheHost }}"
-        - "{{ .Values.global.ironicInspectorHost }}"
+        - '{{ .Values.global.ironicApiHost | default (printf "api.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicInspectorHost | default (printf "inspector.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicBootHost | default (printf "boot.ironic.%s" .Values.global.dnsDomain) }}'
+        - '{{ .Values.global.ironicCacheHost | default (printf "cache.ironic.%s" .Values.global.dnsDomain) }}'
   
 
 letsEncrypt:


### PR DESCRIPTION
Add defaults for the Ironic service endpoints.
This will fix an issue introduced in the previous PR where if the vars in the PR are not provided, the installation will fail