### PR TITLE
Switch back to the upstream charts-build-script

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-CHARTS_BUILD_SCRIPTS_REPO=https://github.com/suse-edge/charts-build-scripts.git
-CHARTS_BUILD_SCRIPT_VERSION=v0.5.1-edge1
+CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
+CHARTS_BUILD_SCRIPT_VERSION=v0.5.5


### PR DESCRIPTION
We no longer need to maintain our versions of the charts-build-scripts, as the issues we had are already fixed in the v0.5.3

closes https://github.com/suse-edge/charts/issues/75