### PR TITLE
Fix small bug in make-html script

### DIFF
--- a/scripts/make-html
+++ b/scripts/make-html
@@ -6,7 +6,7 @@ cd $(dirname $0)
 cd ..
 
 die(){
-	echo ${1} >2&
+	echo ${1} >&2
 	exit ${2}
 }
 


### PR DESCRIPTION
If helm binary does not exist, the current script creates a file named `2` with the error message. I don't think that was the intention