### PR TITLE
kubevirt: add support for affinity and resources

### DIFF
--- a/packages/cdi/charts/templates/cdi-operator.yaml
+++ b/packages/cdi/charts/templates/cdi-operator.yaml
@@ -606,17 +606,7 @@ spec:
         prometheus.cdi.kubevirt.io: "true"
     spec:
       affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: cdi.kubevirt.io
-                      operator: In
-                      values:
-                        - cdi-operator
-                topologyKey: kubernetes.io/hostname
-              weight: 1
+{{- .Values.deployment.affinity | toYaml | nindent 8 }}
       containers:
         - env:
             - name: DEPLOY_CLUSTER_RESOURCES
@@ -650,9 +640,7 @@ spec:
               name: metrics
               protocol: TCP
           resources:
-            requests:
-              cpu: 100m
-              memory: 150Mi
+{{- .Values.deployment.resources | toYaml | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/packages/cdi/charts/values.yaml
+++ b/packages/cdi/charts/values.yaml
@@ -8,6 +8,22 @@ deployment:
   uploadserverImage: registry.suse.com/suse/sles/15.6/cdi-uploadserver
   uploadproxyImage: registry.suse.com/suse/sles/15.6/cdi-uploadproxy
   pullPolicy: IfNotPresent
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: cdi.kubevirt.io
+                  operator: In
+                  values:
+                    - cdi-operator
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 150Mi
 
 cdi:
   config:

--- a/packages/kubevirt/charts/templates/kubevirt-operator.yaml
+++ b/packages/kubevirt/charts/templates/kubevirt-operator.yaml
@@ -1279,17 +1279,7 @@ spec:
       name: virt-operator
     spec:
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: kubevirt.io
-                      operator: In
-                      values:
-                        - virt-operator
-                topologyKey: kubernetes.io/hostname
-              weight: 1
+{{- .Values.operator.affinity | toYaml | nindent 8 }}
       containers:
         - args:
             - --port
@@ -1325,9 +1315,7 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 10
           resources:
-            requests:
-              cpu: 10m
-              memory: 450Mi
+{{- .Values.operator.resources | toYaml | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/packages/kubevirt/charts/templates/kubevirt.yaml
+++ b/packages/kubevirt/charts/templates/kubevirt.yaml
@@ -20,6 +20,10 @@ spec:
   {{- if .Values.kubevirt.uninstallStrategy }}
   uninstallStrategy: {{ .Values.kubevirt.uninstallStrategy }}
   {{- end }}
+  {{- with .Values.kubevirt.workloads }}
+  workloads:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.kubevirt.workloadUpdateStrategy }}
   workloadUpdateStrategy:
   {{- toYaml . | nindent 4 }}

--- a/packages/kubevirt/charts/values.yaml
+++ b/packages/kubevirt/charts/values.yaml
@@ -2,6 +2,22 @@ operator:
   image: registry.suse.com/suse/sles/15.6/virt-operator
   version: 1.3.1-150600.5.9.1
   pullPolicy: IfNotPresent
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: kubevirt.io
+                  operator: In
+                  values:
+                    - virt-operator
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+  resources:
+    requests:
+      cpu: 10m
+      memory: 450Mi
 
 kubevirt:
   # Holds kubevirt configurations. Same as the virt-configMap.
@@ -14,6 +30,8 @@ kubevirt:
   # Specifies if KubeVirt can be deleted if workloads are still present.
   # This is mainly a precaution to avoid accidental data loss.
   uninstallStrategy: ""
+  # Selectors and tolerations that should apply to KubeVirt workloads.
+  workloads: {}
   # WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates.
   workloadUpdateStrategy: {}
   # Optionally enable ServiceMonitor for prometheus, see


### PR DESCRIPTION
> I don't think there is a better repository for deploying KubeVirt with Helm.

This PR is part of the hardening work for KubeVirt and CDI Operator. Along with #161, this PR allows custom values ​​for `affinity` and `resources`. This allows Ops to design more appropriate resource placement for their own environments. The default is AS-IS.

During making this PR, I found that the previous affinity configuration for CDI Operator was incorrect. It should be set to `podAntiAffinity` instead of `podAffinity` like KubeVirt Operator so that the operator pod can be distributed correctly across multiple nodes.
