### PR TITLE
kubevirt: add support for extra annotations

### DIFF
--- a/packages/kubevirt/charts/templates/kubevirt.yaml
+++ b/packages/kubevirt/charts/templates/kubevirt.yaml
@@ -3,6 +3,14 @@ kind: KubeVirt
 metadata:
   name: kubevirt
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.kubevirt.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.kubevirt.labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.kubevirt.configuration }}
   configuration:

--- a/packages/kubevirt/charts/values.yaml
+++ b/packages/kubevirt/charts/values.yaml
@@ -21,6 +21,12 @@ operator:
       memory: 450Mi
 
 kubevirt:
+  # Extra annotations for KubeVirt CR.
+  # Useful for advanced configuration such as:
+  # https://kubevirt.io/user-guide/compute/dedicated_cpu_resources/#compute-nodes-with-smt-enabled
+  annotations: {}
+  # Extra labels for KubeVirt CR.
+  labels: {}
   # Holds kubevirt configurations. Same as the virt-configMap.
   configuration: {}
   customizeComponents: {}


### PR DESCRIPTION
This PR allows users to edit annotations and labels of KubeVirt CR.
It's required to enable SMT (Simultaneous MultiThreading) with static kubelet CPUManager policy and `isolateEmulatorThread`.

NOTE: https://kubevirt.io/user-guide/compute/dedicated_cpu_resources/#compute-nodes-with-smt-enabled
